### PR TITLE
Use semantic text color tokens for risk states

### DIFF
--- a/src/components/MetricsPanel.tsx
+++ b/src/components/MetricsPanel.tsx
@@ -1,10 +1,16 @@
-
 import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { BarChart, Loader2, TrendingUp, TrendingDown, AlertTriangle, Target } from "lucide-react";
+import {
+  BarChart,
+  Loader2,
+  TrendingUp,
+  TrendingDown,
+  AlertTriangle,
+  Target,
+} from "lucide-react";
 import { investmentApi } from "@/services/api";
 
 interface MetricsPanelProps {
@@ -22,11 +28,14 @@ interface Metric {
   alpha?: number;
 }
 
-export function MetricsPanel({ portfolioCodes, securityCodes }: MetricsPanelProps) {
+export function MetricsPanel({
+  portfolioCodes,
+  securityCodes,
+}: MetricsPanelProps) {
   const [metrics, setMetrics] = useState<Metric[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  
+
   // Parameters
   const [metricWinSize, setMetricWinSize] = useState(252);
   const [riskFreeRate, setRiskFreeRate] = useState(0.02);
@@ -66,10 +75,10 @@ export function MetricsPanel({ portfolioCodes, securityCodes }: MetricsPanelProp
 
   const transformMetricsData = (apiData: any): Metric[] => {
     const allCodes = [...portfolioCodes, ...securityCodes];
-    
+
     // Generate sample metrics if API data is not in expected format
     if (!Array.isArray(apiData)) {
-      return allCodes.map(code => ({
+      return allCodes.map((code) => ({
         code,
         sharpe_ratio: Math.random() * 2 - 0.5,
         max_drawdown: -(Math.random() * 0.3 + 0.05),
@@ -84,22 +93,25 @@ export function MetricsPanel({ portfolioCodes, securityCodes }: MetricsPanelProp
   };
 
   const formatPercentage = (value: number | undefined) => {
-    if (value === undefined || value === null) return 'N/A';
+    if (value === undefined || value === null) return "N/A";
     return `${(value * 100).toFixed(2)}%`;
   };
 
   const formatNumber = (value: number | undefined, decimals = 3) => {
-    if (value === undefined || value === null) return 'N/A';
+    if (value === undefined || value === null) return "N/A";
     return value.toFixed(decimals);
   };
 
-  const getMetricColor = (value: number | undefined, type: 'positive' | 'negative') => {
-    if (value === undefined || value === null) return 'text-muted-foreground';
-    
-    if (type === 'positive') {
-      return value > 0 ? 'text-success' : 'text-error';
+  const getMetricColor = (
+    value: number | undefined,
+    type: "positive" | "negative",
+  ) => {
+    if (value === undefined || value === null) return "text-muted-foreground";
+
+    if (type === "positive") {
+      return value > 0 ? "text-success" : "text-destructive";
     } else {
-      return value < 0 ? 'text-error' : 'text-success';
+      return value < 0 ? "text-destructive" : "text-success";
     }
   };
 
@@ -113,7 +125,9 @@ export function MetricsPanel({ portfolioCodes, securityCodes }: MetricsPanelProp
           </CardTitle>
         </CardHeader>
         <CardContent className="flex items-center justify-center h-64">
-          <p className="text-muted-foreground">Select portfolios or securities to view performance metrics</p>
+          <p className="text-muted-foreground">
+            Select portfolios or securities to view performance metrics
+          </p>
         </CardContent>
       </Card>
     );
@@ -186,18 +200,26 @@ export function MetricsPanel({ portfolioCodes, securityCodes }: MetricsPanelProp
                     <div className="flex items-center space-x-2">
                       <Target className="h-4 w-4 text-primary" />
                       <div>
-                        <p className="text-xs text-muted-foreground">Sharpe Ratio</p>
-                        <p className={`font-mono text-sm font-medium ${getMetricColor(metric.sharpe_ratio, 'positive')}`}>
+                        <p className="text-xs text-muted-foreground">
+                          Sharpe Ratio
+                        </p>
+                        <p
+                          className={`font-mono text-sm font-medium ${getMetricColor(metric.sharpe_ratio, "positive")}`}
+                        >
                           {formatNumber(metric.sharpe_ratio)}
                         </p>
                       </div>
                     </div>
-                    
+
                     <div className="flex items-center space-x-2">
                       <TrendingUp className="h-4 w-4 text-chart-2" />
                       <div>
-                        <p className="text-xs text-muted-foreground">Annual Return</p>
-                        <p className={`font-mono text-sm font-medium ${getMetricColor(metric.annual_return, 'positive')}`}>
+                        <p className="text-xs text-muted-foreground">
+                          Annual Return
+                        </p>
+                        <p
+                          className={`font-mono text-sm font-medium ${getMetricColor(metric.annual_return, "positive")}`}
+                        >
                           {formatPercentage(metric.annual_return)}
                         </p>
                       </div>
@@ -206,7 +228,9 @@ export function MetricsPanel({ portfolioCodes, securityCodes }: MetricsPanelProp
                     <div className="flex items-center space-x-2">
                       <AlertTriangle className="h-4 w-4 text-chart-3" />
                       <div>
-                        <p className="text-xs text-muted-foreground">Volatility</p>
+                        <p className="text-xs text-muted-foreground">
+                          Volatility
+                        </p>
                         <p className="font-mono text-sm font-medium financial-number">
                           {formatPercentage(metric.volatility)}
                         </p>
@@ -214,10 +238,12 @@ export function MetricsPanel({ portfolioCodes, securityCodes }: MetricsPanelProp
                     </div>
 
                     <div className="flex items-center space-x-2">
-                      <TrendingDown className="h-4 w-4 text-error" />
+                      <TrendingDown className="h-4 w-4 text-destructive" />
                       <div>
-                        <p className="text-xs text-muted-foreground">Max Drawdown</p>
-                        <p className="font-mono text-sm font-medium text-error financial-number">
+                        <p className="text-xs text-muted-foreground">
+                          Max Drawdown
+                        </p>
+                        <p className="font-mono text-sm font-medium text-destructive financial-number">
                           {formatPercentage(metric.max_drawdown)}
                         </p>
                       </div>
@@ -237,7 +263,9 @@ export function MetricsPanel({ portfolioCodes, securityCodes }: MetricsPanelProp
                       <Target className="h-4 w-4 text-chart-5" />
                       <div>
                         <p className="text-xs text-muted-foreground">Alpha</p>
-                        <p className={`font-mono text-sm font-medium ${getMetricColor(metric.alpha, 'positive')}`}>
+                        <p
+                          className={`font-mono text-sm font-medium ${getMetricColor(metric.alpha, "positive")}`}
+                        >
                           {formatPercentage(metric.alpha)}
                         </p>
                       </div>

--- a/src/components/VarPanel.tsx
+++ b/src/components/VarPanel.tsx
@@ -1,10 +1,15 @@
-
 import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { AlertTriangle, Loader2, Shield } from "lucide-react";
 import { investmentApi } from "@/services/api";
 
@@ -24,7 +29,7 @@ export function VarPanel({ portfolioCodes, securityCodes }: VarPanelProps) {
   const [varData, setVarData] = useState<VarData[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  
+
   // Parameters
   const [varWinSize, setVarWinSize] = useState(252);
   const [confidenceLevel, setConfidenceLevel] = useState(0.95);
@@ -64,10 +69,10 @@ export function VarPanel({ portfolioCodes, securityCodes }: VarPanelProps) {
 
   const transformVarData = (apiData: any): VarData[] => {
     const allCodes = [...portfolioCodes, ...securityCodes];
-    
+
     // Generate sample VaR data if API data is not in expected format
     if (!Array.isArray(apiData)) {
-      return allCodes.map(code => ({
+      return allCodes.map((code) => ({
         code,
         var_value: -(Math.random() * 0.15 + 0.02), // Negative VaR values
         confidence_level: confidenceLevel,
@@ -84,9 +89,21 @@ export function VarPanel({ portfolioCodes, securityCodes }: VarPanelProps) {
 
   const getVarSeverity = (value: number) => {
     const absValue = Math.abs(value);
-    if (absValue > 0.1) return { color: 'text-error', icon: AlertTriangle, severity: 'High Risk' };
-    if (absValue > 0.05) return { color: 'text-warning', icon: AlertTriangle, severity: 'Medium Risk' };
-    return { color: 'text-success', icon: Shield, severity: 'Low Risk' };
+    if (absValue > 0.1) {
+      return {
+        color: "text-destructive",
+        icon: AlertTriangle,
+        severity: "High Risk",
+      };
+    }
+    if (absValue > 0.05) {
+      return {
+        color: "text-warning",
+        icon: AlertTriangle,
+        severity: "Medium Risk",
+      };
+    }
+    return { color: "text-success", icon: Shield, severity: "Low Risk" };
   };
 
   if (portfolioCodes.length === 0 && securityCodes.length === 0) {
@@ -99,7 +116,9 @@ export function VarPanel({ portfolioCodes, securityCodes }: VarPanelProps) {
           </CardTitle>
         </CardHeader>
         <CardContent className="flex items-center justify-center h-64">
-          <p className="text-muted-foreground">Select portfolios or securities to view VaR analysis</p>
+          <p className="text-muted-foreground">
+            Select portfolios or securities to view VaR analysis
+          </p>
         </CardContent>
       </Card>
     );
@@ -128,8 +147,8 @@ export function VarPanel({ portfolioCodes, securityCodes }: VarPanelProps) {
           </div>
           <div className="space-y-2">
             <Label htmlFor="confidenceLevel">Confidence Level</Label>
-            <Select 
-              value={confidenceLevel.toString()} 
+            <Select
+              value={confidenceLevel.toString()}
               onValueChange={(value) => setConfidenceLevel(Number(value))}
             >
               <SelectTrigger>
@@ -171,33 +190,44 @@ export function VarPanel({ portfolioCodes, securityCodes }: VarPanelProps) {
             {varData.map((data) => {
               const severity = getVarSeverity(data.var_value);
               const Icon = severity.icon;
-              
+
               return (
                 <Card key={data.code} className="metric-card">
                   <CardContent className="p-4">
                     <div className="flex items-center justify-between mb-2">
                       <h3 className="font-semibold text-lg">{data.code}</h3>
-                      <div className={`flex items-center gap-1 ${severity.color}`}>
+                      <div
+                        className={`flex items-center gap-1 ${severity.color}`}
+                      >
                         <Icon className="h-4 w-4" />
                         <span className="text-xs">{severity.severity}</span>
                       </div>
                     </div>
-                    
+
                     <div className="space-y-2">
                       <div className="flex justify-between items-center">
-                        <span className="text-sm text-muted-foreground">VaR ({Math.round(data.confidence_level * 100)}%)</span>
-                        <span className={`font-mono font-bold text-lg ${severity.color} financial-number`}>
+                        <span className="text-sm text-muted-foreground">
+                          VaR ({Math.round(data.confidence_level * 100)}%)
+                        </span>
+                        <span
+                          className={`font-mono font-bold text-lg ${severity.color} financial-number`}
+                        >
                           {formatPercentage(data.var_value)}
                         </span>
                       </div>
-                      
+
                       <div className="flex justify-between items-center">
-                        <span className="text-xs text-muted-foreground">Method</span>
-                        <span className="text-xs capitalize">{data.method}</span>
+                        <span className="text-xs text-muted-foreground">
+                          Method
+                        </span>
+                        <span className="text-xs capitalize">
+                          {data.method}
+                        </span>
                       </div>
-                      
+
                       <div className="text-xs text-muted-foreground mt-3">
-                        Expected maximum loss with {Math.round(data.confidence_level * 100)}% confidence
+                        Expected maximum loss with{" "}
+                        {Math.round(data.confidence_level * 100)}% confidence
                       </div>
                     </div>
                   </CardContent>


### PR DESCRIPTION
## Summary
- replace `text-error` with `text-destructive` in VaR and metrics panels
- use semantic `text-warning` and `text-success` tokens for risk severity

## Testing
- `npx prettier -w src/components/VarPanel.tsx src/components/MetricsPanel.tsx`
- `npx eslint . --fix` *(fails: Unexpected any)*
- `npm run lint` *(fails: Unexpected any)*
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_b_689b92148d60832591da58878bbdfc83