### PR TITLE
fix: stabilize ComparisonAnalysis effects

### DIFF
--- a/src/components/ComparisonAnalysis.tsx
+++ b/src/components/ComparisonAnalysis.tsx
@@ -1,11 +1,25 @@
-import { useEffect, useState } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
-import { Network, Loader2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Label } from "@/components/ui/label";
-import { investmentApi } from "@/services/api";
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { Network, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { investmentApi } from '@/services/api';
 
 interface ComparisonAnalysisProps {
   portfolioCodes: string[];
@@ -14,40 +28,114 @@ interface ComparisonAnalysisProps {
 
 type AnalysisType = 'prices' | 'returns' | 'volatility';
 
-export function ComparisonAnalysis({ portfolioCodes, securityCodes }: ComparisonAnalysisProps) {
-  const [data, setData] = useState<any[]>([]);
+interface AnalysisData {
+  [key: string]: number;
+}
+
+interface AnalysisResponse {
+  success: boolean;
+  data?: AnalysisData[];
+}
+
+type CombinedDataPoint = {
+  entity: string;
+  x: number;
+  y: number;
+} & Record<AnalysisType, number>;
+
+export function ComparisonAnalysis({
+  portfolioCodes,
+  securityCodes,
+}: ComparisonAnalysisProps) {
+  const [data, setData] = useState<CombinedDataPoint[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  
+
   const [xAxisType, setXAxisType] = useState<AnalysisType>('prices');
   const [yAxisType, setYAxisType] = useState<AnalysisType>('volatility');
   const [selectedEntities, setSelectedEntities] = useState<string[]>([]);
 
-  const allEntities = [...portfolioCodes, ...securityCodes];
+  const allEntities = useMemo(
+    () => [...portfolioCodes, ...securityCodes],
+    [portfolioCodes, securityCodes],
+  );
 
-  useEffect(() => {
-    if (allEntities.length > 0) {
-      setSelectedEntities(allEntities.slice(0, Math.min(10, allEntities.length))); // Limit to 10 entities
-    }
-  }, [portfolioCodes, securityCodes]);
+  const fetchAnalysisData = useCallback(
+    async (analysisType: AnalysisType): Promise<AnalysisResponse> => {
+      const params = {
+        portfolio_codes: selectedEntities.filter((e) =>
+          portfolioCodes.includes(e),
+        ),
+        security_codes: selectedEntities.filter((e) =>
+          securityCodes.includes(e),
+        ),
+        local_only: true,
+      };
 
-  useEffect(() => {
-    if (selectedEntities.length === 0) {
-      setData([]);
-      return;
-    }
+      switch (analysisType) {
+        case 'prices':
+          return investmentApi.getPrices(params);
+        case 'returns':
+          return investmentApi.getReturns({
+            ...params,
+            use_ln_ret: false,
+            win_size: 30,
+          });
+        case 'volatility':
+          return investmentApi.getRealisedVolatility({
+            ...params,
+            rv_model: 'simple',
+            rv_win_size: 30,
+          });
+        default:
+          return { success: false, error: 'Unknown analysis type' };
+      }
+    },
+    [portfolioCodes, securityCodes, selectedEntities],
+  );
 
-    fetchComparisonData();
-  }, [selectedEntities, xAxisType, yAxisType]);
+  const combineAnalysisData = useCallback(
+    (xData: AnalysisData[], yData: AnalysisData[]): CombinedDataPoint[] => {
+      const combinedData: CombinedDataPoint[] = [];
 
-  const fetchComparisonData = async () => {
+      selectedEntities.forEach((entity) => {
+        // Calculate average values for each entity
+        const xValues = xData
+          .map((item) => item[entity])
+          .filter((v) => v !== undefined);
+        const yValues = yData
+          .map((item) => item[entity])
+          .filter((v) => v !== undefined);
+
+        if (xValues.length > 0 && yValues.length > 0) {
+          const avgX =
+            xValues.reduce((sum, val) => sum + val, 0) / xValues.length;
+          const avgY =
+            yValues.reduce((sum, val) => sum + val, 0) / yValues.length;
+
+          combinedData.push({
+            entity,
+            x: avgX,
+            y: avgY,
+            [xAxisType]: avgX,
+            [yAxisType]: avgY,
+          });
+        }
+      });
+
+      return combinedData;
+    },
+    [selectedEntities, xAxisType, yAxisType],
+  );
+
+  const fetchComparisonData = useCallback(async () => {
     setLoading(true);
     setError(null);
 
     try {
       const [xData, yData] = await Promise.all([
         fetchAnalysisData(xAxisType),
-        fetchAnalysisData(yAxisType)
+        fetchAnalysisData(yAxisType),
       ]);
 
       if (xData.success && yData.success && xData.data && yData.data) {
@@ -64,51 +152,24 @@ export function ComparisonAnalysis({ portfolioCodes, securityCodes }: Comparison
     } finally {
       setLoading(false);
     }
-  };
+  }, [combineAnalysisData, fetchAnalysisData, xAxisType, yAxisType]);
 
-  const fetchAnalysisData = async (analysisType: AnalysisType) => {
-    const params = {
-      portfolio_codes: selectedEntities.filter(e => portfolioCodes.includes(e)),
-      security_codes: selectedEntities.filter(e => securityCodes.includes(e)),
-      local_only: true,
-    };
-
-    switch (analysisType) {
-      case 'prices':
-        return investmentApi.getPrices(params);
-      case 'returns':
-        return investmentApi.getReturns({ ...params, use_ln_ret: false, win_size: 30 });
-      case 'volatility':
-        return investmentApi.getRealisedVolatility({ ...params, rv_model: 'simple', rv_win_size: 30 });
-      default:
-        return { success: false, error: 'Unknown analysis type' };
+  useEffect(() => {
+    if (allEntities.length > 0) {
+      setSelectedEntities(
+        allEntities.slice(0, Math.min(10, allEntities.length)),
+      );
     }
-  };
+  }, [allEntities]);
 
-  const combineAnalysisData = (xData: any[], yData: any[]) => {
-    const combinedData: any[] = [];
+  useEffect(() => {
+    if (selectedEntities.length === 0) {
+      setData([]);
+      return;
+    }
 
-    selectedEntities.forEach(entity => {
-      // Calculate average values for each entity
-      const xValues = xData.map(item => item[entity]).filter(v => v !== undefined);
-      const yValues = yData.map(item => item[entity]).filter(v => v !== undefined);
-
-      if (xValues.length > 0 && yValues.length > 0) {
-        const avgX = xValues.reduce((sum, val) => sum + val, 0) / xValues.length;
-        const avgY = yValues.reduce((sum, val) => sum + val, 0) / yValues.length;
-
-        combinedData.push({
-          entity,
-          x: avgX,
-          y: avgY,
-          [xAxisType]: avgX,
-          [yAxisType]: avgY
-        });
-      }
-    });
-
-    return combinedData;
-  };
+    fetchComparisonData();
+  }, [selectedEntities, xAxisType, yAxisType, fetchComparisonData]);
 
   if (allEntities.length === 0) {
     return (
@@ -120,7 +181,9 @@ export function ComparisonAnalysis({ portfolioCodes, securityCodes }: Comparison
           </CardTitle>
         </CardHeader>
         <CardContent className="flex items-center justify-center h-64">
-          <p className="text-muted-foreground">Select portfolios or securities to view comparison analysis</p>
+          <p className="text-muted-foreground">
+            Select portfolios or securities to view comparison analysis
+          </p>
         </CardContent>
       </Card>
     );
@@ -138,7 +201,10 @@ export function ComparisonAnalysis({ portfolioCodes, securityCodes }: Comparison
         <div className="flex gap-4 items-end">
           <div className="space-y-2">
             <Label>X-Axis</Label>
-            <Select value={xAxisType} onValueChange={(value) => setXAxisType(value as AnalysisType)}>
+            <Select
+              value={xAxisType}
+              onValueChange={(value) => setXAxisType(value as AnalysisType)}
+            >
               <SelectTrigger className="w-32">
                 <SelectValue />
               </SelectTrigger>
@@ -152,7 +218,10 @@ export function ComparisonAnalysis({ portfolioCodes, securityCodes }: Comparison
 
           <div className="space-y-2">
             <Label>Y-Axis</Label>
-            <Select value={yAxisType} onValueChange={(value) => setYAxisType(value as AnalysisType)}>
+            <Select
+              value={yAxisType}
+              onValueChange={(value) => setYAxisType(value as AnalysisType)}
+            >
               <SelectTrigger className="w-32">
                 <SelectValue />
               </SelectTrigger>
@@ -179,30 +248,39 @@ export function ComparisonAnalysis({ portfolioCodes, securityCodes }: Comparison
           </div>
         ) : (
           <ResponsiveContainer width="100%" height={400}>
-            <ScatterChart data={data} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-              <XAxis 
-                type="number" 
-                dataKey="x" 
+            <ScatterChart
+              data={data}
+              margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="hsl(var(--border))"
+              />
+              <XAxis
+                type="number"
+                dataKey="x"
                 name={xAxisType}
                 stroke="hsl(var(--muted-foreground))"
                 fontSize={12}
               />
-              <YAxis 
-                type="number" 
-                dataKey="y" 
+              <YAxis
+                type="number"
+                dataKey="y"
                 name={yAxisType}
                 stroke="hsl(var(--muted-foreground))"
                 fontSize={12}
               />
-              <Tooltip 
+              <Tooltip
                 cursor={{ strokeDasharray: '3 3' }}
                 contentStyle={{
                   backgroundColor: 'hsl(var(--card))',
                   border: '1px solid hsl(var(--border))',
-                  borderRadius: '8px'
+                  borderRadius: '8px',
                 }}
-                formatter={(value: any, name: string) => [value.toFixed(4), name]}
+                formatter={(value: number, name: string) => [
+                  value.toFixed(4),
+                  name,
+                ]}
                 labelFormatter={(label, payload) => {
                   if (payload && payload.length > 0) {
                     return `Entity: ${payload[0].payload.entity}`;
@@ -210,9 +288,9 @@ export function ComparisonAnalysis({ portfolioCodes, securityCodes }: Comparison
                   return label;
                 }}
               />
-              <Scatter 
-                dataKey="y" 
-                fill="hsl(var(--chart-1))" 
+              <Scatter
+                dataKey="y"
+                fill="hsl(var(--chart-1))"
                 fillOpacity={0.7}
                 strokeWidth={2}
                 stroke="hsl(var(--chart-1))"


### PR DESCRIPTION
## Summary
- wrap comparison data fetching helpers with useCallback
- memoize allEntities and add missing effect dependencies
- tighten typings for comparison analysis data

## Testing
- `npx eslint . --fix` *(fails: Unexpected any etc. in unrelated files)*
- `npm run lint` *(fails: existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689b92e0fedc8325a855d6f503332db2