### PR TITLE
Fix toast listener effect to avoid memory leak

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- use an empty dependency array so toast listeners register only once

## Testing
- `npx eslint . --fix`
- `npm run lint` *(fails: 26 errors, 17 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_689b93a4c86c8325a01d8106161f31b8