### PR TITLE
charts: accept external data from comparison analysis

### DIFF
--- a/src/types/charts.ts
+++ b/src/types/charts.ts
@@ -1,0 +1,4 @@
+export interface ChartDataPoint {
+  date: string;
+  [key: string]: number | string;
+}


### PR DESCRIPTION
## Summary
- allow price, returns, and volatility charts to render external data and loading state
- centralize ChartDataPoint interface for reuse

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689ba903474c8325a0175542ab7b1d34