### PR TITLE
comparison-analysis: revoke blob URL after export

### DIFF
--- a/src/components/ComparisonAnalysis.tsx
+++ b/src/components/ComparisonAnalysis.tsx
@@ -158,6 +158,7 @@ export function ComparisonAnalysis({
       a.href = url;
       a.download = `comparison_${activeTab}_${new Date().toISOString().split('T')[0]}.csv`;
       a.click();
+      URL.revokeObjectURL(url);
     }
   };
 


### PR DESCRIPTION
## Summary
- release object URL after CSV export to free memory

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689c7da53a048325a3b21e5edafa382a