### PR TITLE
api: encode URL codes in service requests

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -46,7 +46,7 @@ class InvestmentApiService {
 
   // Portfolio endpoints
   async getPortfolio(code: string) {
-    return this.makeRequest(`/core/portfolio/${code}`);
+    return this.makeRequest(`/core/portfolio/${encodeURIComponent(code)}`);
   }
 
   async getPortfolios(codes: string[]) {
@@ -58,7 +58,7 @@ class InvestmentApiService {
 
   // Security endpoints
   async getSecurity(code: string) {
-    return this.makeRequest(`/core/security/${code}`);
+    return this.makeRequest(`/core/security/${encodeURIComponent(code)}`);
   }
 
   async getSecurities(codes: string[]) {


### PR DESCRIPTION
## Summary
- encode portfolio and security codes in API service requests to sanitize URLs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689c7daa9cbc8325a0e5516d152b8551