### PR TITLE
Streamline dashboard navigation and mixed-metric comparison

### DIFF
--- a/src/components/ComparisonAnalysis.tsx
+++ b/src/components/ComparisonAnalysis.tsx
@@ -1,9 +1,6 @@
-import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Select,
   SelectContent,
@@ -11,9 +8,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { PriceChart } from './PriceChart';
-import { ReturnsChart } from './ReturnsChart';
-import { VolatilityChart } from './VolatilityChart';
 import { investmentApi } from '@/services/api';
 import { useSettings } from '@/hooks/use-settings';
 import {
@@ -21,297 +15,389 @@ import {
   generateMockReturnsData,
   generateMockVolatilityData,
 } from '@/services/testData';
-import { TrendingUp, BarChart3, Activity, FileText } from 'lucide-react';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from 'recharts';
+import { Plus, Trash2 } from 'lucide-react';
 
 interface ComparisonAnalysisProps {
   portfolioCodes: string[];
   securityCodes: string[];
 }
 
-interface AnalysisSeries {
-  [key: string]: any;
+type Metric = 'price' | 'return' | 'volatility';
+type Normalize = 'none' | 'index' | 'zscore';
+
+interface SeriesConfig {
+  id: string;
+  code: string;
+  metric: Metric;
+  axis: 'left' | 'right';
+  normalize: Normalize;
+  color: string;
+  data: { date: string; value: number }[];
 }
+
+const colors = [
+  'hsl(var(--chart-1))',
+  'hsl(var(--chart-2))',
+  'hsl(var(--chart-3))',
+  'hsl(var(--chart-4))',
+  'hsl(var(--chart-5))',
+];
 
 export function ComparisonAnalysis({
   portfolioCodes,
   securityCodes,
 }: ComparisonAnalysisProps) {
-  const [activeTab, setActiveTab] = useState('prices');
-  const [baseCurrency, setBaseCurrency] = useState('USD');
   const { useTestData, defaultDateRange } = useSettings();
+  const availableCodes = useMemo(
+    () => [...portfolioCodes, ...securityCodes],
+    [portfolioCodes, securityCodes],
+  );
+  const [seriesConfigs, setSeriesConfigs] = useState<SeriesConfig[]>([]);
+  const [newCode, setNewCode] = useState('');
+  const [newMetric, setNewMetric] = useState<Metric>('price');
+  const [newNormalize, setNewNormalize] = useState<Normalize>('none');
 
-  const allCodes = [...portfolioCodes, ...securityCodes];
+  useEffect(() => {
+    if (availableCodes.length > 0 && !newCode) {
+      setNewCode(availableCodes[0]);
+    }
+  }, [availableCodes, newCode]);
 
-  const combineAnalysisData = (data: AnalysisSeries[]): AnalysisSeries[] => {
-    if (!Array.isArray(data) || data.length === 0) return [];
+  const fetchSeriesData = async (
+    code: string,
+    metric: Metric,
+  ): Promise<{ date: string; value: number }[]> => {
+    const params = {
+      portfolio_codes: portfolioCodes.includes(code) ? [code] : undefined,
+      security_codes: securityCodes.includes(code) ? [code] : undefined,
+    };
 
-    const dateMap = new Map();
-
-    data.forEach((series) => {
-      if (Array.isArray(series)) {
-        series.forEach((point: any) => {
-          if (point.date) {
-            if (!dateMap.has(point.date)) {
-              dateMap.set(point.date, { date: point.date });
-            }
-            const existing = dateMap.get(point.date);
-            Object.keys(point).forEach((key) => {
-              if (key !== 'date') {
-                existing[key] = point[key];
-              }
-            });
-          }
-        });
+    if (useTestData) {
+      switch (metric) {
+        case 'price':
+          return generateMockPriceData(code, defaultDateRange).map(
+            (d: any) => ({
+              date: d.date,
+              value: d.value,
+            }),
+          );
+        case 'return':
+          return generateMockReturnsData(code, defaultDateRange).map(
+            (d: any) => ({
+              date: d.date,
+              value: d.value,
+            }),
+          );
+        case 'volatility':
+          return generateMockVolatilityData(code, defaultDateRange).map(
+            (d: any) => ({
+              date: d.date,
+              value: d.value,
+            }),
+          );
       }
-    });
+    } else {
+      switch (metric) {
+        case 'price': {
+          const res = await investmentApi.getPrices(params);
+          return (res.data || []).map((d: any) => ({
+            date: d.date,
+            value: d[code],
+          }));
+        }
+        case 'return': {
+          const res = await investmentApi.getReturns(params);
+          return (res.data || []).map((d: any) => ({
+            date: d.date,
+            value: d[code],
+          }));
+        }
+        case 'volatility': {
+          const res = await investmentApi.getRealisedVolatility(params);
+          return (res.data || []).map((d: any) => ({
+            date: d.date,
+            value: d[code],
+          }));
+        }
+      }
+    }
+    return [];
+  };
 
-    return Array.from(dateMap.values()).sort(
+  const normalizeData = (
+    data: { date: string; value: number }[],
+    mode: Normalize,
+  ) => {
+    if (mode === 'index') {
+      const base = data[0]?.value || 1;
+      return data.map((d) => ({ ...d, value: (d.value / base) * 100 }));
+    }
+    if (mode === 'zscore') {
+      const mean =
+        data.reduce((sum, d) => sum + d.value, 0) / (data.length || 1);
+      const std =
+        Math.sqrt(
+          data.reduce((sum, d) => sum + Math.pow(d.value - mean, 2), 0) /
+            (data.length || 1),
+        ) || 1;
+      return data.map((d) => ({ ...d, value: (d.value - mean) / std }));
+    }
+    return data;
+  };
+
+  const refreshSeries = async (
+    config: SeriesConfig,
+    metric: Metric = config.metric,
+    normalize: Normalize = config.normalize,
+  ) => {
+    const raw = await fetchSeriesData(config.code, metric);
+    const data = normalizeData(raw, normalize);
+    return { ...config, metric, normalize, data } as SeriesConfig;
+  };
+
+  const addSeries = async () => {
+    if (!newCode) return;
+    const id = `${newCode}-${newMetric}`;
+    if (seriesConfigs.some((s) => s.id === id)) return;
+    const raw = await fetchSeriesData(newCode, newMetric);
+    const data = normalizeData(raw, newNormalize);
+    const axis =
+      seriesConfigs.length > 0 && seriesConfigs[0].metric !== newMetric
+        ? 'right'
+        : 'left';
+    const color = colors[seriesConfigs.length % colors.length];
+    setSeriesConfigs([
+      ...seriesConfigs,
+      {
+        id,
+        code: newCode,
+        metric: newMetric,
+        axis,
+        normalize: newNormalize,
+        color,
+        data,
+      },
+    ]);
+  };
+
+  const removeSeries = (id: string) => {
+    setSeriesConfigs(seriesConfigs.filter((s) => s.id !== id));
+  };
+
+  const handleMetricChange = async (id: string, metric: Metric) => {
+    const existing = seriesConfigs.find((s) => s.id === id);
+    if (!existing) return;
+    const updated = await refreshSeries(existing, metric, existing.normalize);
+    updated.axis =
+      seriesConfigs[0]?.metric && seriesConfigs[0].metric !== metric
+        ? 'right'
+        : 'left';
+    setSeriesConfigs((prev) => prev.map((s) => (s.id === id ? updated : s)));
+  };
+
+  const handleNormalizeChange = async (id: string, mode: Normalize) => {
+    const existing = seriesConfigs.find((s) => s.id === id);
+    if (!existing) return;
+    const updated = await refreshSeries(existing, existing.metric, mode);
+    setSeriesConfigs((prev) => prev.map((s) => (s.id === id ? updated : s)));
+  };
+
+  const handleAxisChange = (id: string, axis: 'left' | 'right') => {
+    setSeriesConfigs((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, axis } : s)),
+    );
+  };
+
+  const mergedData = () => {
+    const map = new Map<string, any>();
+    seriesConfigs.forEach((series) => {
+      series.data.forEach((point) => {
+        if (!map.has(point.date)) {
+          map.set(point.date, { date: point.date });
+        }
+        map.get(point.date)[series.id] = point.value;
+      });
+    });
+    return Array.from(map.values()).sort(
       (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
     );
   };
 
-  const generateTestData = (type: string) => {
-    const data: AnalysisSeries[] = [];
-    allCodes.forEach((code) => {
-      switch (type) {
-        case 'prices':
-          data.push(generateMockPriceData(code, defaultDateRange) as any);
-          break;
-        case 'returns':
-          data.push(generateMockReturnsData(code, defaultDateRange) as any);
-          break;
-        case 'volatility':
-          data.push(generateMockVolatilityData(code, defaultDateRange) as any);
-          break;
-      }
-    });
-    return { success: true, data: combineAnalysisData(data) };
-  };
-
-  const pricesQuery = useQuery({
-    queryKey: [
-      'comparison-prices',
-      portfolioCodes,
-      securityCodes,
-      useTestData,
-      baseCurrency,
-    ],
-    queryFn: async () => {
-      if (useTestData) {
-        return generateTestData('prices');
-      }
-      const pricesResponse = await investmentApi.getPrices({
-        portfolio_codes: portfolioCodes.length > 0 ? portfolioCodes : undefined,
-        security_codes: securityCodes.length > 0 ? securityCodes : undefined,
-        currency: baseCurrency,
-      });
-      return {
-        ...pricesResponse,
-        data: Array.isArray(pricesResponse.data) ? pricesResponse.data : [],
-      };
-    },
-    enabled: allCodes.length > 0,
-  });
-
-  const returnsQuery = useQuery({
-    queryKey: [
-      'comparison-returns',
-      portfolioCodes,
-      securityCodes,
-      useTestData,
-    ],
-    queryFn: async () => {
-      if (useTestData) {
-        return generateTestData('returns');
-      }
-      const returnsResponse = await investmentApi.getReturns({
-        portfolio_codes: portfolioCodes.length > 0 ? portfolioCodes : undefined,
-        security_codes: securityCodes.length > 0 ? securityCodes : undefined,
-      });
-      return {
-        ...returnsResponse,
-        data: Array.isArray(returnsResponse.data) ? returnsResponse.data : [],
-      };
-    },
-    enabled: allCodes.length > 0,
-  });
-
-  const volatilityQuery = useQuery({
-    queryKey: [
-      'comparison-volatility',
-      portfolioCodes,
-      securityCodes,
-      useTestData,
-    ],
-    queryFn: async () => {
-      if (useTestData) {
-        return generateTestData('volatility');
-      }
-      const volatilityResponse = await investmentApi.getRealisedVolatility({
-        portfolio_codes: portfolioCodes.length > 0 ? portfolioCodes : undefined,
-        security_codes: securityCodes.length > 0 ? securityCodes : undefined,
-      });
-      return {
-        ...volatilityResponse,
-        data: Array.isArray(volatilityResponse.data)
-          ? volatilityResponse.data
-          : [],
-      };
-    },
-    enabled: allCodes.length > 0,
-  });
-
-  const exportData = (format: 'csv') => {
-    const currentData = getCurrentData();
-    console.log(`Exporting data as ${format}:`, currentData);
-
-    // Export as CSV timeseries
-    const csvContent = [
-      ['Date', ...allCodes].join(','),
-      ...currentData.map((row) =>
-        [row.date, ...allCodes.map((code) => row[code] || '')].join(','),
-      ),
-    ].join('\n');
-
-    const blob = new Blob([csvContent], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `comparison_${activeTab}_${new Date().toISOString().split('T')[0]}.csv`;
-    a.click();
-    URL.revokeObjectURL(url);
-  };
-
-  if (allCodes.length === 0) {
-    return (
-      <Card className="glass">
-        <CardContent className="flex items-center justify-center h-64">
-          <div className="text-center">
-            <BarChart3 className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-            <h3 className="text-lg font-medium text-muted-foreground">
-              No Data Selected
-            </h3>
-            <p className="text-sm text-muted-foreground mt-2">
-              Select portfolios or securities to view comparison analysis
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-    );
-  }
-
-  const getCurrentData = () => {
-    switch (activeTab) {
-      case 'prices':
-        return pricesQuery.data?.data || [];
-      case 'returns':
-        return returnsQuery.data?.data || [];
-      case 'volatility':
-        return volatilityQuery.data?.data || [];
-      default:
-        return [];
-    }
-  };
-
-  const getCurrentLoading = () => {
-    switch (activeTab) {
-      case 'prices':
-        return pricesQuery.isLoading;
-      case 'returns':
-        return returnsQuery.isLoading;
-      case 'volatility':
-        return volatilityQuery.isLoading;
-      default:
-        return false;
-    }
-  };
-
   return (
-    <div className="space-y-6">
-      <Card className="glass">
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle className="flex items-center gap-2">
-              <BarChart3 className="h-5 w-5" />
-              Comparison Analysis
-              {useTestData && (
-                <Badge variant="secondary" className="text-xs">
-                  Test Data
-                </Badge>
-              )}
-            </CardTitle>
-            <div className="flex items-center gap-2">
-              <Select value={baseCurrency} onValueChange={setBaseCurrency}>
-                <SelectTrigger className="w-24">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="USD">USD</SelectItem>
-                  <SelectItem value="EUR">EUR</SelectItem>
-                  <SelectItem value="GBP">GBP</SelectItem>
-                  <SelectItem value="JPY">JPY</SelectItem>
-                </SelectContent>
-              </Select>
-
-              <div className="flex items-center gap-1">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => exportData('csv')}
-                >
-                  <FileText className="h-4 w-4 mr-1" />
-                  CSV
-                </Button>
-              </div>
-            </div>
+    <Card className="glass">
+      <CardHeader>
+        <CardTitle>Comparison Analysis</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="space-y-1">
+            <Select value={newCode} onValueChange={setNewCode}>
+              <SelectTrigger className="w-40">
+                <SelectValue placeholder="Entity" />
+              </SelectTrigger>
+              <SelectContent>
+                {availableCodes.map((code) => (
+                  <SelectItem key={code} value={code}>
+                    {code}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
-        </CardHeader>
-        <CardContent>
-          <Tabs value={activeTab} onValueChange={setActiveTab}>
-            <TabsList className="grid w-full grid-cols-3">
-              <TabsTrigger value="prices" className="flex items-center gap-2">
-                <TrendingUp className="h-4 w-4" />
-                Prices
-              </TabsTrigger>
-              <TabsTrigger value="returns" className="flex items-center gap-2">
-                <BarChart3 className="h-4 w-4" />
-                Returns
-              </TabsTrigger>
-              <TabsTrigger
-                value="volatility"
-                className="flex items-center gap-2"
-              >
-                <Activity className="h-4 w-4" />
-                Volatility
-              </TabsTrigger>
-            </TabsList>
+          <div className="space-y-1">
+            <Select
+              value={newMetric}
+              onValueChange={(v) => setNewMetric(v as Metric)}
+            >
+              <SelectTrigger className="w-36">
+                <SelectValue placeholder="Metric" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="price">Price</SelectItem>
+                <SelectItem value="return">Return</SelectItem>
+                <SelectItem value="volatility">Volatility</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <Select
+              value={newNormalize}
+              onValueChange={(v) => setNewNormalize(v as Normalize)}
+            >
+              <SelectTrigger className="w-32">
+                <SelectValue placeholder="Normalize" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">None</SelectItem>
+                <SelectItem value="index">Index 100</SelectItem>
+                <SelectItem value="zscore">Z-Score</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <Button onClick={addSeries} size="icon">
+            <Plus className="h-4 w-4" />
+          </Button>
+        </div>
 
-            <TabsContent value="prices" className="mt-6">
-              <PriceChart
-                data={getCurrentData()}
-                selectedCodes={allCodes}
-                loading={getCurrentLoading()}
-              />
-            </TabsContent>
+        {seriesConfigs.map((series) => (
+          <div key={series.id} className="flex flex-wrap items-end gap-2">
+            <div className="text-sm font-medium w-24">{series.code}</div>
+            <Select
+              value={series.metric}
+              onValueChange={(v) => handleMetricChange(series.id, v as Metric)}
+            >
+              <SelectTrigger className="w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="price">Price</SelectItem>
+                <SelectItem value="return">Return</SelectItem>
+                <SelectItem value="volatility">Volatility</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select
+              value={series.normalize}
+              onValueChange={(v) =>
+                handleNormalizeChange(series.id, v as Normalize)
+              }
+            >
+              <SelectTrigger className="w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">None</SelectItem>
+                <SelectItem value="index">Index 100</SelectItem>
+                <SelectItem value="zscore">Z-Score</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select
+              value={series.axis}
+              onValueChange={(v) =>
+                handleAxisChange(series.id, v as 'left' | 'right')
+              }
+            >
+              <SelectTrigger className="w-24">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="left">Left Axis</SelectItem>
+                <SelectItem value="right">Right Axis</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => removeSeries(series.id)}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
 
-            <TabsContent value="returns" className="mt-6">
-              <ReturnsChart
-                data={getCurrentData()}
-                selectedCodes={allCodes}
-                loading={getCurrentLoading()}
+        <div className="w-full h-96">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart
+              data={mergedData()}
+              margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="hsl(var(--border))"
               />
-            </TabsContent>
-
-            <TabsContent value="volatility" className="mt-6">
-              <VolatilityChart
-                data={getCurrentData()}
-                selectedCodes={allCodes}
-                loading={getCurrentLoading()}
+              <XAxis
+                dataKey="date"
+                stroke="hsl(var(--muted-foreground))"
+                fontSize={12}
               />
-            </TabsContent>
-          </Tabs>
-        </CardContent>
-      </Card>
-    </div>
+              {seriesConfigs.some((s) => s.axis === 'left') && (
+                <YAxis
+                  yAxisId="left"
+                  stroke="hsl(var(--muted-foreground))"
+                  fontSize={12}
+                />
+              )}
+              {seriesConfigs.some((s) => s.axis === 'right') && (
+                <YAxis
+                  yAxisId="right"
+                  orientation="right"
+                  stroke="hsl(var(--muted-foreground))"
+                  fontSize={12}
+                />
+              )}
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: 'hsl(var(--card))',
+                  border: '1px solid hsl(var(--border))',
+                  borderRadius: '8px',
+                }}
+              />
+              <Legend />
+              {seriesConfigs.map((series) => (
+                <Line
+                  key={series.id}
+                  type="monotone"
+                  dataKey={series.id}
+                  stroke={series.color}
+                  strokeWidth={2}
+                  dot={false}
+                  yAxisId={series.axis}
+                  name={`${series.code} ${series.metric}`}
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -3,44 +3,29 @@ import { Outlet, useLocation, Link } from 'react-router-dom';
 import {
   LayoutDashboard,
   BarChart3,
-  TrendingUp,
   Upload,
   Shuffle,
   Settings,
-  Menu,
-  Search,
-  Bell,
-  Calendar,
-  AlertTriangle,
-  ChevronLeft,
-  ChevronRight,
+  PanelLeft,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { ThemeToggle } from '@/components/ThemeToggle';
-import { useSettings } from '@/hooks/use-settings';
 import { cn } from '@/lib/utils';
 
 const navigationItems = [
   { name: 'Overview', href: '/dashboard', icon: LayoutDashboard },
-  { name: 'Portfolios', href: '/dashboard/portfolios', icon: BarChart3 },
-  { name: 'Securities', href: '/dashboard/securities', icon: TrendingUp },
+  {
+    name: 'Portfolios & Securities',
+    href: '/dashboard/portfolios',
+    icon: BarChart3,
+  },
   { name: 'Comparison', href: '/dashboard/comparison', icon: Shuffle },
   { name: 'Data Uploads', href: '/dashboard/uploads', icon: Upload },
 ];
 
 export function DashboardLayout() {
   const location = useLocation();
-  const { useTestData } = useSettings();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
-  const [globalCurrency, setGlobalCurrency] = useState('USD');
 
   const isActive = (href: string) => {
     return (
@@ -52,8 +37,8 @@ export function DashboardLayout() {
   const getBreadcrumbs = () => {
     const path = location.pathname;
     if (path === '/dashboard') return 'Overview';
-    if (path.includes('portfolios')) return 'Portfolios';
-    if (path.includes('securities')) return 'Securities';
+    if (path.includes('portfolios') || path.includes('securities'))
+      return 'Portfolios & Securities';
     if (path.includes('comparison')) return 'Entity Comparison';
     if (path.includes('uploads')) return 'Data Uploads';
     if (path.includes('settings')) return 'Settings';
@@ -87,49 +72,11 @@ export function DashboardLayout() {
               onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
               className="h-8 w-8"
             >
-              <Menu className="h-4 w-4" />
+              <PanelLeft className="h-4 w-4" />
             </Button>
           </div>
-
-          {/* Center Section - Controls */}
-          <div className="flex items-center gap-4">
-            <div className="flex items-center gap-2">
-              <Calendar className="h-4 w-4 text-muted-foreground" />
-              <Button variant="outline" size="sm" className="h-8 text-xs">
-                Last 12M
-              </Button>
-            </div>
-
-            <Select value={globalCurrency} onValueChange={setGlobalCurrency}>
-              <SelectTrigger className="w-16 h-8 text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="USD">USD</SelectItem>
-                <SelectItem value="EUR">EUR</SelectItem>
-                <SelectItem value="GBP">GBP</SelectItem>
-                <SelectItem value="JPY">JPY</SelectItem>
-              </SelectContent>
-            </Select>
-
-            <div className="relative">
-              <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder="Search..."
-                className="w-48 h-8 pl-8 text-xs"
-              />
-            </div>
-          </div>
-
           {/* Right Section - Status & Actions */}
           <div className="flex items-center gap-3">
-            {useTestData && (
-              <div className="flex items-center gap-1.5 px-2 py-1 bg-warning/10 border border-warning/20 rounded text-xs">
-                <AlertTriangle className="h-3 w-3 text-warning" />
-                <span className="text-warning font-medium">Test Mode</span>
-              </div>
-            )}
-
             <div className="text-xs text-muted-foreground">
               Updated:{' '}
               {new Date().toLocaleTimeString([], {
@@ -137,11 +84,6 @@ export function DashboardLayout() {
                 minute: '2-digit',
               })}
             </div>
-
-            <Button variant="ghost" size="icon" className="h-8 w-8">
-              <Bell className="h-3.5 w-3.5" />
-            </Button>
-
             <ThemeToggle />
           </div>
         </div>
@@ -192,28 +134,6 @@ export function DashboardLayout() {
               <Settings className="h-4 w-4 flex-shrink-0" />
               {!sidebarCollapsed && <span>Settings</span>}
             </Link>
-          </div>
-
-          {/* Collapse Toggle */}
-          <div className="p-3 border-t">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
-              className={cn(
-                'w-full h-8 text-xs',
-                sidebarCollapsed ? 'px-2' : '',
-              )}
-            >
-              {sidebarCollapsed ? (
-                <ChevronRight className="h-3.5 w-3.5" />
-              ) : (
-                <>
-                  <ChevronLeft className="h-3.5 w-3.5 mr-1" />
-                  Collapse
-                </>
-              )}
-            </Button>
           </div>
         </aside>
 

--- a/src/components/EntitySelector.tsx
+++ b/src/components/EntitySelector.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
@@ -158,11 +157,6 @@ export function EntitySelector({ onSelectionChange }: EntitySelectorProps) {
           <CardTitle className="flex items-center gap-2">
             <Search className="h-5 w-5 text-muted-foreground" />
             Entity Selection
-            {useTestData && (
-              <Badge variant="secondary" className="text-xs">
-                Test Mode
-              </Badge>
-            )}
           </CardTitle>
         </CardHeader>
         <CardContent>

--- a/src/pages/PortfolioOverview.tsx
+++ b/src/pages/PortfolioOverview.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Table,
@@ -148,16 +147,7 @@ export function PortfolioOverview() {
             Comprehensive view of your investment holdings and performance
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          {useTestData && (
-            <div className="flex items-center gap-2 px-3 py-1 bg-amber-100 dark:bg-amber-900/20 border border-amber-300 dark:border-amber-700 rounded-lg">
-              <div className="w-2 h-2 bg-amber-500 rounded-full"></div>
-              <span className="text-sm text-amber-700 dark:text-amber-300">
-                Test Data Mode Active
-              </span>
-            </div>
-          )}
-        </div>
+        <div className="flex items-center gap-2"></div>
       </div>
 
       {/* View Toggle */}


### PR DESCRIPTION
## Summary
- Simplify dashboard shell: drop bottom collapse, filters, bell, and test-mode badge
- Merge portfolio & security links and use top toggle for sidebar
- Redesign comparison analysis to mix metrics per entity with dual axes and normalization

## Testing
- `npm run lint`
- `npm run build`
- `npm run preview`


------
https://chatgpt.com/codex/tasks/task_b_68b342f71eec83259ab86f7ef641e328